### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     ],
     keywords='materials informatics crystal structures crystal-structure crystallography CRYSTAL ab-initio ab-initio-simulations first-principles materials-science',
     packages=['pycrystal'],
-    install_requires=['ase', 'pyparsing', 'requests', 'bs4'],
+    install_requires=['ase', 'pyparsing', 'requests', 'beautifulsoup4'],
     python_requires='>=3.5'
 )


### PR DESCRIPTION
`bs4` is just a dummy package for `beautifulsoup4`, so it is recommended to link to `beautifulsoup4` rather than `bs4`.  https://pypi.org/project/bs4/